### PR TITLE
Ignore machine credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ node_modules/
 # Environment variables
 .env
 
+# Machine credentials (protects API tokens)
+.cursor/mcp.json
+.roo/mcp.json
+
 # Editor directories and files
 .idea
 .vscode


### PR DESCRIPTION
## Summary
- protect sensitive machine credential files by ignoring `.cursor/mcp.json` and `.roo/mcp.json`

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_b_68556ad194f8832dbe1e1dbe61fde112