### PR TITLE
Add auditor workflow for pull requests

### DIFF
--- a/.github/workflows/check-artifacts.yml
+++ b/.github/workflows/check-artifacts.yml
@@ -1,0 +1,27 @@
+name: Check Output Artifacts
+
+on:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Run checklist auditor
+        run: node update_output_artifacts_checklist.js
+
+      - name: Fail if files changed
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Output Artifacts checklists need updates. Run 'node update_output_artifacts_checklist.js' and commit the changes." >&2
+            git status --porcelain
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ DafnckMachine uses Task Master for all task, subtask, and workflow management.
 
 ---
 
+## ✅ Output Artifacts Audit Workflow
+
+This repository uses a GitHub Actions workflow to keep all "Output Artifacts Checklist" sections in sync.
+
+1. Every pull request triggers `.github/workflows/check-artifacts.yml`.
+2. The workflow runs `node update_output_artifacts_checklist.js` to audit the Markdown files.
+3. If the script modifies any files, the job fails and lists the affected files. Run the script locally and commit the changes to resolve the failure.
+
+---
+
 ## ⚙️ MCP Server Configuration
 
 DafnckMachine uses MCP servers for advanced agent and workflow integration (Cursor, RooCode, Task Master, etc).


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs the output artifacts auditor
- fail the workflow when files need updates
- explain the workflow in the README so contributors know how it works

## Testing
- `node update_output_artifacts_checklist.js`

------
https://chatgpt.com/codex/tasks/task_b_685a688dddd4832db82c8948f3a7d882