### PR TITLE
Add Jest and Pytest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,17 @@ This repository uses a GitHub Actions workflow to keep all "Output Artifacts Che
 
 ---
 
+## 🧪 Testing
+
+Run the automated tests from the repository root:
+
+```bash
+npx jest    # JavaScript tests
+pytest      # Python tests
+```
+
+---
+
 ## ⚙️ MCP Server Configuration
 
 DafnckMachine uses MCP servers for advanced agent and workflow integration (Cursor, RooCode, Task Master, etc).

--- a/fix_documentation_paths.js
+++ b/fix_documentation_paths.js
@@ -82,5 +82,13 @@ function main() {
     }
 }
 
-// Execute the script
-main();
+// Execute the script only when run directly
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    updateFilePaths,
+    findMarkdownFiles,
+    main
+};

--- a/tests/fix_documentation_paths.test.js
+++ b/tests/fix_documentation_paths.test.js
@@ -1,0 +1,7 @@
+const { updateFilePaths } = require('../fix_documentation_paths.js');
+
+test('replaces old documentation paths', () => {
+  const input = 'See 01_Machine/04_Documentation/Doc/file.md for details.';
+  const output = updateFilePaths(input);
+  expect(output).toBe('See 01_Machine/04_Documentation/vision/file.md for details.');
+});

--- a/tests/test_unified_agent_validator.py
+++ b/tests/test_unified_agent_validator.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add validator directory to path
+VALIDATOR_PATH = Path(__file__).resolve().parents[1] / '01_Machine' / '03_Brain' / 'Agents-Check'
+sys.path.insert(0, str(VALIDATOR_PATH))
+
+import unified_agent_validator as uav
+
+@pytest.fixture
+def validator():
+    return uav.AgentValidator(Path(__file__))
+
+def minimal_agent(slug='test-agent'):
+    instr = ('**Core Purpose**\n**Key Capabilities**\n**Operational Process**\n'
+             '**Technical Outputs**\n**Domain Specializations**\n**Quality Standards**\n**MCP Tools**')
+    return {
+        'customModes': [{
+            'slug': slug,
+            'name': 'Test',
+            'roleDefinition': 'Role',
+            'customInstructions': instr,
+            'groups': ['read', 'edit', 'mcp', 'command'],
+            'inputSpec': {'type': 'json', 'format': 'text', 'example': 'ex', 'schema': {}, 'validationRules': {}},
+            'outputSpec': {'type': 'json', 'format': 'text', 'example': 'ex', 'schema': {}, 'validationRules': {}},
+            'errorHandling': 'eh',
+            'healthCheck': 'hc'
+        }]
+    }
+
+def test_basic_structure_valid(validator):
+    data = minimal_agent('valid-agent')
+    errors = validator._validate_basic_structure(data, Path('valid-agent.json'))
+    assert errors == []
+
+def test_basic_structure_slug_mismatch(validator):
+    data = minimal_agent('wrong')
+    errors = validator._validate_basic_structure(data, Path('right.json'))
+    assert any('slug' in e for e in errors)
+
+def test_detailed_fields_missing_name(validator):
+    data = minimal_agent()
+    del data['customModes'][0]['name']
+    errors, warnings = validator._validate_detailed_fields(data, Path('x.json'))
+    assert any("name" in e for e in errors)

--- a/tests/update_output_artifacts_checklist.test.js
+++ b/tests/update_output_artifacts_checklist.test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const OutputArtifactsAuditor = require('../update_output_artifacts_checklist.js');
+
+test('adds missing checklist based on output artifacts', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-'));
+  const filePath = path.join(tmpDir, 'step.md');
+  const fileContent = `---\n\n# Step\n\n## Output Artifacts\n[Example](mdc:03_Project/file.md): Example`;
+
+  fs.writeFileSync(filePath, fileContent);
+
+  const auditor = new OutputArtifactsAuditor();
+  auditor.workflowDir = tmpDir;
+  await auditor.run();
+
+  const updated = fs.readFileSync(filePath, 'utf8');
+  expect(updated).toMatch(/## Output Artifacts Checklist/);
+  expect(updated).toMatch(/03_Project\/file.md/);
+});


### PR DESCRIPTION
## Summary
- export functions from `fix_documentation_paths.js` for testing
- add Jest tests for the two JS scripts
- test Python agent validator with pytest
- explain how to run tests in README

## Testing
- `npx jest tests/fix_documentation_paths.test.js tests/update_output_artifacts_checklist.test.js`
- `pytest tests/test_unified_agent_validator.py -q`


------
https://chatgpt.com/codex/tasks/task_b_685a6d32a654832dbf0a6a0b39414802