### PR TITLE
Handle symlink loops in node scripts

### DIFF
--- a/fix_documentation_paths.js
+++ b/fix_documentation_paths.js
@@ -15,7 +15,11 @@ function findMarkdownFiles(dir) {
         
         for (const item of items) {
             const fullPath = path.join(currentDir, item);
-            const stat = fs.statSync(fullPath);
+            const stat = fs.lstatSync(fullPath);
+
+            if (stat.isSymbolicLink()) {
+                continue; // Skip symbolic links to avoid loops
+            }
             
             if (stat.isDirectory()) {
                 traverse(fullPath);
@@ -82,5 +86,9 @@ function main() {
     }
 }
 
-// Execute the script
-main();
+// Execute the script only when run directly
+if (require.main === module) {
+    main();
+}
+
+module.exports = { findMarkdownFiles, updateFilePaths, main };

--- a/tests/symlink_loop.test.js
+++ b/tests/symlink_loop.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+
+const { findMarkdownFiles } = require('../fix_documentation_paths');
+const OutputArtifactsAuditor = require('../update_output_artifacts_checklist');
+
+function setupTempDir() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dm-test-'));
+  const workflow = path.join(tmp, 'workflow');
+  fs.mkdirSync(workflow);
+  const sub = path.join(workflow, 'phase1');
+  fs.mkdirSync(sub);
+  fs.writeFileSync(path.join(sub, 'file1.md'), '# Test');
+  // create symlink loop
+  fs.symlinkSync(workflow, path.join(workflow, 'loop'));
+  return { tmp, workflow };
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+(function testSkipSymlink() {
+  const { tmp, workflow } = setupTempDir();
+  try {
+    const files1 = findMarkdownFiles(workflow);
+    assert.strictEqual(files1.length, 1, 'findMarkdownFiles should ignore symlinks');
+
+    const auditor = new OutputArtifactsAuditor();
+    auditor.workflowDir = workflow;
+    const files2 = auditor.discoverWorkflowFiles();
+    assert.strictEqual(files2.length, 1, 'discoverWorkflowFiles should ignore symlinks');
+
+    console.log('Symlink loop test passed');
+  } finally {
+    cleanup(tmp);
+  }
+})();

--- a/update_output_artifacts_checklist.js
+++ b/update_output_artifacts_checklist.js
@@ -75,7 +75,11 @@ class OutputArtifactsAuditor {
                 
                 for (const item of items) {
                     const fullPath = path.join(dir, item);
-                    const stat = fs.statSync(fullPath);
+                    const stat = fs.lstatSync(fullPath);
+
+                    if (stat.isSymbolicLink()) {
+                        continue; // Skip symbolic links
+                    }
                     
                     if (stat.isDirectory()) {
                         scanDirectory(fullPath);


### PR DESCRIPTION
## Summary
- avoid following symlinks while traversing directories
- export functions from `fix_documentation_paths.js`
- add regression test ensuring loops are ignored

## Testing
- `node tests/symlink_loop.test.js`

------
https://chatgpt.com/codex/tasks/task_b_685a6d336ca0832dacecf8dadc6d70ac