### PR TITLE
Refactor file access to async fs.promises

### DIFF
--- a/fix_documentation_paths.js
+++ b/fix_documentation_paths.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const fsp = fs.promises;
 
 // Configuration
 const WORKFLOW_DIR = '01_Machine/01_Workflow';
@@ -36,7 +37,7 @@ function updateFilePaths(content) {
 }
 
 // Main execution
-function main() {
+async function main() {
     console.log('🔧 Starting documentation path correction...');
     console.log(`📁 Scanning directory: ${WORKFLOW_DIR}`);
     console.log(`🔄 Converting: ${OLD_PATH} → ${NEW_PATH}`);
@@ -51,14 +52,14 @@ function main() {
     // Process each file
     for (const filePath of markdownFiles) {
         try {
-            const content = fs.readFileSync(filePath, 'utf8');
+            const content = await fsp.readFile(filePath, 'utf8');
             const updatedContent = updateFilePaths(content);
             
             // Count replacements in this file
             const replacements = (content.match(new RegExp(OLD_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
             
             if (replacements > 0) {
-                fs.writeFileSync(filePath, updatedContent, 'utf8');
+                await fsp.writeFile(filePath, updatedContent, 'utf8');
                 updatedCount++;
                 totalReplacements += replacements;
                 console.log(`✅ Updated ${filePath} (${replacements} replacements)`);
@@ -83,4 +84,7 @@ function main() {
 }
 
 // Execute the script
-main();
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/update_output_artifacts_checklist.js
+++ b/update_output_artifacts_checklist.js
@@ -17,6 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const fsp = fs.promises;
 
 class OutputArtifactsAuditor {
     constructor() {
@@ -97,7 +98,7 @@ class OutputArtifactsAuditor {
      */
     async analyzeFile(filePath) {
         try {
-            const content = fs.readFileSync(filePath, 'utf8');
+            const content = await fsp.readFile(filePath, 'utf8');
             const lines = content.split('\n');
             
             const analysis = {
@@ -394,7 +395,7 @@ class OutputArtifactsAuditor {
      * Update a single file's checklist
      */
     async updateSingleFile(analysis) {
-        const content = fs.readFileSync(analysis.filePath, 'utf8');
+        const content = await fsp.readFile(analysis.filePath, 'utf8');
         const lines = content.split('\n');
         
         if (analysis.checklistLine === -1) {
@@ -406,7 +407,7 @@ class OutputArtifactsAuditor {
         }
         
         const updatedContent = lines.join('\n');
-        fs.writeFileSync(analysis.filePath, updatedContent, 'utf8');
+        await fsp.writeFile(analysis.filePath, updatedContent, 'utf8');
     }
 
     /**


### PR DESCRIPTION
## Summary
- rewrite `sync_agents.js` with async fs operations
- migrate `fix_documentation_paths.js` to fs.promises
- use async reads/writes in `update_output_artifacts_checklist.js`

## Testing
- `node -e 'new Function(require("fs").readFileSync("scripts/sync_agents.js","utf8").replace(/^#!.*\n/, ""));'`
- `node -e 'new Function(require("fs").readFileSync("fix_documentation_paths.js","utf8").replace(/^#!.*\n/, ""));'`
- `node -e 'new Function(require("fs").readFileSync("update_output_artifacts_checklist.js","utf8").replace(/^#!.*\n/, ""));'`

------
https://chatgpt.com/codex/tasks/task_b_685a6d351afc832da7322e23a593372b